### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ ng-input is a fork from [codrops - Text Input Effects](https://github.com/codrop
 
 # Install
 
-####Install using `bower`
+#### Install using `bower`
 
     bower install ng-input
   
-####Install using `npm`
+#### Install using `npm`
 
     npm install ng-input
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
